### PR TITLE
Only test on one database

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Save coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: .coverage.${{ matrix.database }}.py${{ matrix.python-version }}
-          path: .coverage.${{ matrix.database }}.py${{ matrix.python-version }}
+          name: .coverage.dj${{ matrix.django-version }}.py${{ matrix.python-version }}
+          path: .coverage.dj${{ matrix.django-version }}.py${{ matrix.python-version }}
           include-hidden-files: true
 
   codecov:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             version="django~=${{ matrix.django-version }}.0"
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
-      - run: uv run --with ${{ steps.django-version.outputs.version }} pytest --cov --cov-report=
+      - run: uv run --with "${{ steps.django-version.outputs.version }}" pytest --cov --cov-report=
       - name: Rename coverage file
         run:
           mv .coverage .coverage.dj${{ matrix.django-version }}.py${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,15 @@ on: push
 
 jobs:
   pytest:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        django-version:
+        - "4.2"
+        - "5.0"
+        - "5.1"
+        - "5.2"
         python-version:
         - "3.8"
         - "3.9"
@@ -14,51 +20,53 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
-        database: [sqlite, mysql, pg2, pg3]
+        include:
+        - django-version: "main"
+          python-version: "3.12"
+        - django-version: "main"
+          python-version: "3.13"
+        exclude:
+        - django-version: "4.2"
+          python-version: "3.13"
+        - django-version: "5.0"
+          python-version: "3.8"
+        - django-version: "5.0"
+          python-version: "3.9"
+        - django-version: "5.0"
+          python-version: "3.13"
+        - django-version: "5.1"
+          python-version: "3.8"
+        - django-version: "5.1"
+          python-version: "3.9"
+        - django-version: "5.1"
+          python-version: "3.13"
+        - django-version: "5.2"
+          python-version: "3.8"
+        - django-version: "5.2"
+          python-version: "3.9"
 
-    services:
-      mariadb:
-        image: ${{ (matrix.database == 'mysql') && 'mariadb' || '' }}
-        env:
-          MARIADB_ROOT_PASSWORD: django_safemigrate
-        options: >-
-          --health-cmd "mariadb-admin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-        - 3306:3306
-      postgres:
-        image: ${{ (matrix.database == 'pg2' || matrix.database == 'pg3') && 'postgres' || '' }}
-        env:
-          POSTGRES_DB: django_safemigrate
-          POSTGRES_USER: django_safemigrate
-          POSTGRES_PASSWORD: django_safemigrate
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv pip install tox-uv tox-gh-actions coverage[toml]
-      - name: Run tox
-        env:
-          DB: ${{ matrix.database }}
-          PGSQL_DATABASE_URL: postgresql://django_safemigrate:django_safemigrate@localhost/django_safemigrate
-          MYSQL_DATABASE_URL: mysql://root:django_safemigrate@127.0.0.1/django_safemigrate
-        run: tox
-      - name: Prepare coverage file
+      - run: uv sync
+      - name: Determine Django version specifier
+        id: django-version
         run: |
-          coverage combine
-          mv .coverage .coverage.${{ matrix.database }}.py${{ matrix.python-version }}
+          if [[ "${{ matrix.django-version }}" == "main" ]]; then
+            version="django @ https://github.com/django/django/archive/main.tar.gz"
+          elif [[ "${{ matrix.django-version }}" == "5.2" ]]; then
+            version="django~=5.2a"
+          else
+            # Use the latest patch version
+            version="django~=${{ matrix.django-version }}.0"
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - run: uv run --with ${{ steps.django-version.outputs.version }} pytest --cov --cov-report=
+      - name: Rename coverage file
+        run:
+          mv .coverage .coverage.dj${{ matrix.django-version }}.py${{ matrix.python-version }}
       - name: Save coverage file
         uses: actions/upload-artifact@v4
         with:
@@ -78,9 +86,9 @@ jobs:
         with:
           pattern: .coverage.*
           merge-multiple: true
-      - run: uv pip install coverage[toml]
-      - run: coverage combine
-      - run: coverage xml
+      - run: |
+          uv run coverage combine
+          uv run coverage xml
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ profile = "black"
 
 [tool.coverage.run]
 branch = true
-parallel = true
 source = ["django_safemigrate"]
 
 [tool.coverage.paths]

--- a/tox.ini
+++ b/tox.ini
@@ -1,46 +1,21 @@
 [tox]
 isolated_build = True
 envlist =
-    dj{42  }-py{38,39,310,311,312    }-{sqlite,pg2,pg3,mysql}
-    dj{50  }-py{      310,311,312    }-{sqlite,pg2,pg3,mysql}
-    dj{51  }-py{      310,311,312,313}-{sqlite,pg2,pg3,mysql}
-    dj{52  }-py{      310,311,312,313}-{sqlite,pg2,pg3,mysql}
-    dj{main}-py{              312,313}-{sqlite,pg2,pg3,mysql}
+    dj{42  }-py{38,39,310,311,312    }
+    dj{50  }-py{      310,311,312    }
+    dj{51  }-py{      310,311,312,313}
+    dj{52  }-py{      310,311,312,313}
+    dj{main}-py{              312,313}
 
 [testenv]
-pip_pre = True
 deps =
     dj42: django~=4.2.0
     dj50: django~=5.0.0
     dj51: django~=5.1.0
     dj52: django~=5.2a1
     djmain: https://github.com/django/django/archive/main.tar.gz
-    pg2: psycopg2-binary
-    pg3: psycopg[binary]
-    mysql: mysqlclient
 dependency_groups = dev
-setenv =
-    PYTHONWARNINGS = d
-    pg2,pg3: DATABASE_URL = {env:PGSQL_DATABASE_URL:postgresql://django_safemigrate:django_safemigrate@localhost/django_safemigrate}
-    mysql: DATABASE_URL = {env:MYSQL_DATABASE_URL:mysql://django_safemigrate:django_safemigrate@127.0.0.1/django_safemigrate}
-commands =
-    python -m coverage run -m pytest {posargs}
-
-[gh-actions]
-python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313
-
-[gh-actions:env]
-DB =
-    mysql: mysql
-    pg2: pg2
-    pg3: pg3
-    sqlite: sqlite
+commands = pytest
 
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.testproject.settings


### PR DESCRIPTION
Don't use tox for running in GitHub actions, and skip running tests on multiple databases. We're not using special features, so functionally it's only testing the ORM.