### PR TITLE
Adjust the migration categorization algorithm

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Breaking Changes:
 * Change the default safe marking to ``Safe.always``.
   This gives a better default experience for working with third-party apps.
 * Disallow faking migrations when using ``safemigrate``.
+* ``Safe.after_deploy`` and ``Safe.always`` migrations will be
+  reported as blocked if they are behind a blocked ``Safe.before_deploy``
+  migration.
+* ``Safe.after_deploy`` migrations are now reported along with other
+  delayed migrations instead of being separately reported as protected.
 
 Other improvements:
 

--- a/tests/safemigrate_test.py
+++ b/tests/safemigrate_test.py
@@ -587,7 +587,7 @@ class TestSafeMigrate:
                 Migration(
                     "spam",
                     "0002_followup",
-                    safe=Safe.after_deploy(),
+                    safe=Safe.after_deploy(delay=timedelta(days=1)),
                     dependencies=[("spam", "0001_initial")],
                 ),
                 False,
@@ -598,6 +598,15 @@ class TestSafeMigrate:
                     "0003_safety",
                     safe=Safe.before_deploy(),
                     dependencies=[("spam", "0002_followup")],
+                ),
+                False,
+            ),
+            (
+                Migration(
+                    "spam",
+                    "0004_blocked",
+                    safe=Safe.after_deploy(delay=timedelta(days=1)),
+                    dependencies=[("spam", "0003_safety")],
                 ),
                 False,
             ),


### PR DESCRIPTION
To simplify the output and mental model of the categorization needed for safemigrate, eliminate the protected category by combining it with the delayed category, and expand the blocked category to include migrations that are only blocked because they are behind a blocked migration.

This allows for a clearer conceptual linearization of safemigrate's categorizations of migrations, so that they now flow from ready to delayed to blocked through the dependency graph.

```
+-----+    +-------+    +-------+
|ready| -> |delayed| -> |blocked|
+-----+    +-------+    +-------+
```