### PR TITLE
Restore the ability to use None for SAFEMIGRATE

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,12 @@
+5.2 (2025-04-02)
+++++++++++++++++
+
+* Fix undocumented backward incompatible change
+  that caused ``None`` to no longer be allowed
+  as the value of the ``SAFEMIGRATE`` setting.
+* Warn when ``None`` is used as the value of ``SAFEMIGRATE``,
+  instead of the preferred ``"strict"`` value.
+
 5.1 (2025-03-27)
 ++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ then add this to the ``repos`` key of your ``.pre-commit-config.yaml``:
 
     repos:
         -   repo: https://github.com/ryanhiebert/django-safemigrate
-            rev: "5.1"
+            rev: "5.2"
             hooks:
             -   id: check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safemigrate"
-version = "5.1"
+version = "5.2"
 description = "Safely run migrations before deployment"
 authors = [{ name = "Ryan Hiebert", email = "ryan@ryanhiebert.com" }]
 license = { text = "MIT" }

--- a/tests/safemigrate_test.py
+++ b/tests/safemigrate_test.py
@@ -536,6 +536,20 @@ class TestSafeMigrate:
         with pytest.raises(ValueError):
             receiver(plan=plan)
 
+    def test_safemigrate_none_value(self, settings, receiver):
+        """``None`` is valid but deprecated, and means ``strict``."""
+        settings.SAFEMIGRATE = None
+        plan = []
+        with pytest.warns(DeprecationWarning):
+            receiver(plan=plan)
+
+    def test_safemigrate_non_string_value(self, settings, receiver):
+        """Non-string values for the SAFEMIGRATE setting will raise an error."""
+        settings.SAFEMIGRATE = 1
+        plan = []
+        with pytest.raises(ValueError):
+            receiver(plan=plan)
+
     def test_string_invalid(self, receiver):
         """Invalid settings of the safe property will raise an error."""
         plan = [(Migration("spam", "0001_initial", safe="before_deploy"), False)]


### PR DESCRIPTION
This was previously permitted, and unintentionally broken in 5.0. Deprecate the use of None, and prefer explicit use of "strict" instead.

Fix #106 